### PR TITLE
Score is rendered no matter navigation

### DIFF
--- a/app/scripts.babel/score.js
+++ b/app/scripts.babel/score.js
@@ -1,11 +1,9 @@
 'use strict';
 
-start();
-
 /**
  * Starts the score calculation
  */
-function start() {
+function load() {
   let score = getScore();
   writeScore(score);
 }
@@ -21,18 +19,35 @@ function getScore() {
 }
 
 /**
+ * Verifies if the repository is public or private
+ * @return {boolean} true if it is public, else false
+ */
+function repositoryIsPublic() {
+  // TODO should find a better way to verify. Maybe using the GitHub API(?)
+  if(document.getElementsByClassName('public')[0] !== undefined) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Gets the node subtree where the score box will be inserted at
+ * @return {object} the node subtree
+ */
+ function getSubtreeToInsert() {
+  if (repositoryIsPublic()) {
+    return(document.getElementsByClassName('public')[0]);
+  }
+  return(document.getElementsByClassName('private')[0]);
+}
+
+/**
  * Writes the score block to the DOM
  * @param {object} score The score values
  */
 function writeScore(score) {
   let nodeToInsert = getNodeToInsert(score);
-
-  // TODO should find a better way to verify. Maybe using the GitHub API(?)
-  let repoTopName = document.getElementsByClassName('public')[0];
-  if(repoTopName === undefined) {
-    repoTopName = document.getElementsByClassName('private')[0];
-  }
-
+  let repoTopName = getSubtreeToInsert();
   repoTopName.insertBefore(nodeToInsert, repoTopName.firstChild);
 }
 
@@ -45,3 +60,23 @@ function getNodeToInsert(score) {
   let node = document.createTextNode(score.aggregate + '');
   return node;
 }
+
+/**
+* @param {object} e The click event
+* TODO we shouldn't be bypassing AJAX
+* Finds out when a link is opened though AJAX, and just reloads the target,
+* essentialy bypassing the use of AJAX
+*/
+window.onclick = function(e) {
+  if (e.target.tagName === 'A') {
+    // clicked a link and DOM will be reloaded
+    window.location.href = e.target.href;
+  } else if (e.target.tagName === 'SPAN') {
+    // check if contained in an <a> tag
+    if (e.target.parentNode.tagName === 'A') {
+      window.location.href = e.target.parentNode.href;
+    }
+  }
+};
+
+window.onhashchange = load();

--- a/app/scripts.babel/score.js
+++ b/app/scripts.babel/score.js
@@ -80,3 +80,7 @@ window.onclick = function(e) {
 };
 
 window.onhashchange = load();
+
+window.addEventListener('popstate', function(event) {
+  window.location.href = event.target.location.href;
+}, false);


### PR DESCRIPTION
Solves https://github.com/ngbravo/gitscore/issues/4

Essentially it avoid the use of AJAX to load links altogether. It just forces the page to load completely.